### PR TITLE
Add optimizations in DataRowConvertor.ToType (Fixes #41)

### DIFF
--- a/Src/Core/Convertor/DataReaderConvertor.cs
+++ b/Src/Core/Convertor/DataReaderConvertor.cs
@@ -1,4 +1,5 @@
-﻿using Apps72.Dev.Data.Schema;
+﻿using Apps72.Dev.Data.Annotations;
+using Apps72.Dev.Data.Schema;
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
@@ -319,6 +320,23 @@ namespace Apps72.Dev.Data.Convertor
             return properties.FirstOrDefault(prop => String.Compare(Annotations.ColumnAttribute.GetColumnAttributeName(prop), columnName, StringComparison.InvariantCultureIgnoreCase) == 0 && prop.CanWrite)
                    ??
                    properties.FirstOrDefault(prop => String.Compare(prop.Name, columnName, StringComparison.InvariantCultureIgnoreCase) == 0);
+        }
+
+        internal static IDictionary<string, PropertyInfo> ToDictionaryWithAttributeOrName(this IEnumerable<PropertyInfo> properties)
+        {
+            var props = new Dictionary<string, PropertyInfo>(StringComparer.InvariantCultureIgnoreCase);
+            var orderedProperties = properties.OrderBy(prop => prop.GetCustomAttributes(typeof(ColumnAttribute), false).Count() == 0); // Properties with attribute "ColumnAttribute" take priorities
+                                                                                                                                       // over other property with same name.
+            foreach (var property in orderedProperties)
+            {
+                var attributeName = Annotations.ColumnAttribute.GetColumnAttributeName(property);
+                var key = string.IsNullOrEmpty(attributeName) ? property.Name : attributeName;
+                if (!props.ContainsKey(key))
+                {
+                    props.Add(key, property);
+                }
+            }
+            return props;
         }
     }
 

--- a/Src/Core/Convertor/DataRowConvertor.cs
+++ b/Src/Core/Convertor/DataRowConvertor.cs
@@ -19,14 +19,15 @@ namespace Apps72.Dev.Data.Convertor
 
             // *** Class
             else
-            {                
-                var properties = rowType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            {
+                var properties = rowType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                                        .ToDictionaryWithAttributeOrName();
                 var newItem = Activator.CreateInstance<T>();
 
                 foreach (var column in row.Table.Columns)
                 {
                     var name = column.ColumnName;
-                    var property = properties.GetFirstOrDefaultWithAttributeOrName(name);
+                    var property = properties.GetValueOrDefault(name);
                     if (property != null)
                     {
                         var value = row[name];

--- a/Src/Core/DictionaryExtensions.cs
+++ b/Src/Core/DictionaryExtensions.cs
@@ -12,9 +12,9 @@ namespace Apps72.Dev.Data
         /// <typeparam name="TValue">The value type of the dictionary.</typeparam>
         /// <param name="dictionary">The dictionnary to lookup.</param>
         /// <param name="key">The search to search for.</param>
-        /// <param name="defaultValue">The default value if no key is found.</param>
+        /// <param name="defaultValue">The default value if no key is found. By default, it is the default value or <typeparamref name="TValue"/>.</param>
         /// <returns>The value associated to the specified key. If the key does not exists, <paramref name="defaultValue"/> is returned.</returns>
-        internal static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue = default(TValue)) where TValue : struct
+        internal static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue = default(TValue))
         {
             return dictionary.TryGetValue(key, out TValue value) ? value : defaultValue;
         }

--- a/Src/Core/DictionaryExtensions.cs
+++ b/Src/Core/DictionaryExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace Apps72.Dev.Data
+{
+    internal static class DictionaryExtensions
+    {
+        /// <summary>
+        /// Tries to get the value associated with the specified key in the dictionary.
+        /// <paramref name="defaultValue"/> is returned if the key does not exists.
+        /// </summary>
+        /// <typeparam name="TKey">The key type of the dictionary.</typeparam>
+        /// <typeparam name="TValue">The value type of the dictionary.</typeparam>
+        /// <param name="dictionary">The dictionnary to lookup.</param>
+        /// <param name="key">The search to search for.</param>
+        /// <param name="defaultValue">The default value if no key is found.</param>
+        /// <returns>The value associated to the specified key. If the key does not exists, <paramref name="defaultValue"/> is returned.</returns>
+        internal static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue = default(TValue)) where TValue : struct
+        {
+            return dictionary.TryGetValue(key, out TValue value) ? value : defaultValue;
+        }
+    }
+}

--- a/Test/Core/ExecuteRowTests.cs
+++ b/Test/Core/ExecuteRowTests.cs
@@ -1,6 +1,6 @@
-using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Apps72.Dev.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Data.SqlClient;
 
 namespace Data.Core.Tests
@@ -290,14 +290,15 @@ namespace Data.Core.Tests
                 cmd.Log = Console.WriteLine;
                 cmd.CommandText = @"SELECT EMP.EMPNO,
                                             EMP.ENAME,                                         
-                                            DEPT.DNAME
+                                            DEPT.DNAME,
+                                            EMP.MGR
                                         FROM EMP 
                                         INNER JOIN DEPT ON DEPT.DEPTNO = EMP.DEPTNO
                                         WHERE EMPNO = 7369";
 
 
 
-                var smith = cmd.ExecuteRow(row => 
+                var smith = cmd.ExecuteRow(row =>
                 {
                     MyEmployee emp = row.MapTo<MyEmployee>();
                     emp.Department = row.MapTo<MyDepartment>();
@@ -308,6 +309,8 @@ namespace Data.Core.Tests
                 Assert.AreEqual("SMITH", smith.EName);
                 Assert.AreEqual(null, smith.Salary);
                 Assert.AreEqual(null, smith.SAL);
+                Assert.AreEqual(EMP.Smith.Manager, smith.Manager);
+                Assert.AreEqual(null, smith.MGR);       // Not used, because there are a Manager property tagged [Column("MGR")]
 
                 Assert.AreEqual(0, smith.Department.DeptNo);
                 Assert.AreEqual("RESEARCH", smith.Department.DName);
@@ -327,7 +330,7 @@ namespace Data.Core.Tests
                                       FROM EMP 
                                      WHERE EMPNO = 7369";
 
-                
+
                 var smith = cmd.ExecuteRow<EMP>();
 
                 Assert.AreEqual(7369, smith.EmpNo);
@@ -338,7 +341,7 @@ namespace Data.Core.Tests
 
         }
 
-        class MyEmployee : EMP 
+        class MyEmployee : EMP
         {
             public MyDepartment Department { get; set; }
         };

--- a/Test/Core/ExecuteTableTests.cs
+++ b/Test/Core/ExecuteTableTests.cs
@@ -205,12 +205,12 @@ namespace Data.Core.Tests
                 var smith = employees.First();
 
                 Assert.AreEqual(14, employees.Count());
-                Assert.AreEqual(EMP.Smith.EmpNo, smith.EmpNo);
-                Assert.AreEqual(EMP.Smith.EName, smith.EName);
-                Assert.AreEqual(EMP.Smith.Salary, smith.Salary);
-                Assert.AreEqual(EMP.Smith.HireDate, smith.HireDate);
-                Assert.AreEqual(EMP.Smith.Comm, smith.Comm);
-                Assert.AreEqual(EMP.Smith.Manager, smith.Manager);
+                Assert.AreEqual(7369, smith.EmpNo);
+                Assert.AreEqual("SMITH", smith.EName);
+                Assert.AreEqual(800, smith.Salary);
+                Assert.AreEqual(new DateTime(1980, 12, 17), smith.HireDate);
+                Assert.AreEqual(null, smith.Comm);
+                Assert.AreEqual(7902, smith.Manager);
                 Assert.AreEqual("RESEARCH", smith.Department.DName);
             }
         }


### PR DESCRIPTION
Hi,

I've fixed the issue #41 with these changes.
This prevent properties to be lookuped multiples times in DataRow.MapTo method.

1. Add **PropertyInfo[].ToDictionaryWithAttributeOrName** extension method: This convert a list of **PropertyInfo** objects to a dictionary. The key is computed from the attribute **ColumnAttribute** and the property name. Properties with ColumnAttribute "override" the property name.
2. Add **Dictionary.GetValueOrDefault** extension method: This method get the value of the specified key. If the dictionary does not contains the key, the method returns the default value of the type.
3. Change **DataRowConvertor.ToType** methods: A dictionary of properties is computed before looping over all data result columns.
4. Add some unit tests.