### PR TITLE
Provides a "Ignore" attribute to ignore properties when mapping the POCO class to the entity

### DIFF
--- a/Src/Core/Annotations/IgnoreAttribute.cs
+++ b/Src/Core/Annotations/IgnoreAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Apps72.Dev.Data.Annotations
+{
+    /// <summary>
+    /// Specifies that the property shouldn't be part of the database mapping.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class IgnoreAttribute : Attribute
+    {
+    }
+}

--- a/Src/Core/Convertor/TypeExtension.cs
+++ b/Src/Core/Convertor/TypeExtension.cs
@@ -40,7 +40,8 @@ namespace Apps72.Dev.Data.Convertor
                    type == typeof(UIntPtr) || type == typeof(Nullable<UIntPtr>) ||
                    type == typeof(Char) || type == typeof(Nullable<Char>) ||
                    type == typeof(Double) || type == typeof(Nullable<Double>) ||
-                   type == typeof(Single) || type == typeof(Nullable<Single>);
+                   type == typeof(Single) || type == typeof(Nullable<Single>) ||
+                   type == typeof(Guid) || type == typeof(Nullable<Guid>);
         }
 
         /// <summary>

--- a/Src/Core/Schema/DataParameter.cs
+++ b/Src/Core/Schema/DataParameter.cs
@@ -1,9 +1,10 @@
-﻿using Apps72.Dev.Data.Convertor;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
 using System.Reflection;
+using Apps72.Dev.Data.Annotations;
+using Apps72.Dev.Data.Convertor;
 
 namespace Apps72.Dev.Data.Schema
 {
@@ -59,6 +60,9 @@ namespace Apps72.Dev.Data.Schema
                 List<DbParameter> parameters = new List<DbParameter>();
                 foreach (PropertyInfo property in typeof(T).GetProperties())
                 {
+                    if (property.GetCustomAttribute<IgnoreAttribute>() != null)
+                        continue;
+
                     if (TypeExtension.IsPrimitive(property.PropertyType))
                     {
                         // Data type
@@ -76,15 +80,12 @@ namespace Apps72.Dev.Data.Schema
                             parameter.Value = DBNull.Value;
 
                         // Parameter name
+                        parameter.ParameterName = property.Name;
+                            
                         string attribute = Apps72.Dev.Data.Annotations.ColumnAttribute.GetColumnAttributeName(property);
-                        if (string.IsNullOrEmpty(attribute))
-                        {
-                            parameter.ParameterName = property.Name;
-                        }
-                        else
-                        {
+                        if (!string.IsNullOrEmpty(attribute))
                             parameter.ParameterName = attribute;
-                        }
+
 
                         parameters.Add(parameter);
                     }


### PR DESCRIPTION
Allows to ignore some properties marked by a specific attribute when mapping the POCO class to the query paremeters
Adds Guid to the list of "primitive" types